### PR TITLE
feat: dc/default-command-action

### DIFF
--- a/discord/src/main/kotlin/net/dustrean/modules/discord/util/commands/InputCommandExtension.kt
+++ b/discord/src/main/kotlin/net/dustrean/modules/discord/util/commands/InputCommandExtension.kt
@@ -15,7 +15,12 @@ private val listener = kord.on<GuildChatInputCommandInteractionCreateEvent> {
         if (interaction.command.rootName != it.name) return@forEach
         val data = interaction.command.data
         val options = data.options.value
-        options?.forEach{ optionData ->
+        if (options.isNullOrEmpty()) {
+            val perform = it.actions["_default"] ?: return@on
+            perform(this)
+            return@on
+        }
+        options.forEach{ optionData ->
             val groupName = optionData.name
             if (optionData.subCommands.value == null || optionData.subCommands.value!!.isEmpty()) {
                 val perform = it.actions[groupName] ?: return@on //group name is here the subcommand name


### PR DESCRIPTION
This make it possible to have a default action for a command. The action key for the default action is "_default" (https://github.com/dustrean-network/modules/blob/216511a64c3c6ca3346a3d151858f0d92617cea2/discord/src/main/kotlin/net/dustrean/modules/discord/util/commands/InputCommandExtension.kt#L60)
 e. g.:
`perform { 
    //do something
}`